### PR TITLE
bench-build: subagenci raportują postęp w tasks/<nazwa>/todo.md

### DIFF
--- a/.agents/skills/bench-build/REPORT_TEMPLATE.md
+++ b/.agents/skills/bench-build/REPORT_TEMPLATE.md
@@ -13,7 +13,8 @@ wyniki komend, nie deklaracje.
 
 <pełna lista utworzonych/zmienionych ścieżek: tasks/<nazwa>/…, nowe
 asercje w evaluation-pool/…, zbiór kalibracyjny
-w evaluation-pool/judge/<zadanie>-calibration/…>
+w evaluation-pool/judge/<zadanie>-calibration/…; bez todo.md — plik
+postępu usuwasz przy oddaniu pracy>
 
 ## Co zadanie mierzy
 

--- a/.agents/skills/bench-build/SKILL.md
+++ b/.agents/skills/bench-build/SKILL.md
@@ -155,6 +155,11 @@ w prompcie:
   zmieniać pod nim w trakcie (sąsiad dopisuje swoje katalogi), więc
   ponowny skan puli w trakcie pracy niczego nie rozstrzyga — wiąże go
   twoje rozstrzygnięcie, a rozbieżność z nim zgłasza w raporcie;
+- przypomnienie o podglądzie postępu: pierwszą czynnością subagenta
+  jest utworzenie `tasks/<nazwa>/todo.md` (krok 0 procedury),
+  aktualizowanego bezpośrednio po każdym kroku — przez ten plik ty
+  i użytkownik podglądacie pracę w toku, więc ma być pisany na
+  bieżąco, nie uzupełniany wstecz przed raportem;
 - format raportu końcowego: REPORT_TEMPLATE.md (lista plików, dowody
   z referencji, koszt) + problemy.
 
@@ -163,6 +168,15 @@ aktualnym repo, bug nieobserwowalny) — to poprawny wynik, nie porażka
 orkiestracji.
 
 ### 4. Zbiór wyników i statusy
+
+W trakcie pracy subagentów postęp podglądasz w ich plikach
+`tasks/<nazwa>/todo.md` — każdy prowadzi swój na bieżąco (krok 0
+TASK_AUTHORING.md) i to tam patrzysz najpierw, gdy któryś utknie albo
+użytkownik pyta o stan paczki. Podglądasz, nie edytujesz (zasada 1);
+przy oddaniu pracy subagent sam usuwa swój todo.md — jeśli po jego
+raporcie plik został, przypomnij mu o sprzątnięciu albo odnotuj to
+użytkownikowi jako resztkę do usunięcia (plik roboczy wszedłby
+w `task_hash`).
 
 Po każdym subagencie: (w trybie domyślnym jego pliki są już w drzewie
 instancji; tylko przy izolowanych kopiach przenieś je — zasada 5),

--- a/.agents/skills/bench-build/TASK_AUTHORING.md
+++ b/.agents/skills/bench-build/TASK_AUTHORING.md
@@ -65,6 +65,13 @@ zbudowane na domysłach.
    i pracuj wyłącznie tam; sporadyczny `index.lock` po prostu ponów.
    Jeśli klonu brakuje, zgłoś to w raporcie zamiast klonować obok
    innych subagentów.
+9. **Postęp raportujesz na bieżąco w `tasks/<nazwa>/todo.md`.** To
+   jedyny kanał podglądu twojej pracy w toku — orkiestrator
+   i użytkownik czytają go, zanim wrócisz z raportem. Tworzysz go jako
+   pierwszą czynność (krok 0 procedury), aktualizujesz bezpośrednio po
+   każdym kroku (nie zbiorczo na końcu), a przy oddaniu pracy usuwasz:
+   `task_hash` liczy się ze **wszystkich** plików katalogu zadania,
+   więc pozostawiony plik roboczy wszedłby na stałe w tożsamość ery.
 
 ## Narzędzia runnera
 
@@ -91,6 +98,36 @@ Uruchamiane z korzenia instancji: `node --experimental-strip-types
   `bench evaluate --run <dir>` — próbny pełny cykl (krok 6).
 
 ## Procedura
+
+### 0. Plan pracy — todo.md
+
+Zanim cokolwiek zbudujesz, utwórz `tasks/<nazwa>/todo.md` (razem
+z katalogiem zadania, jeśli jeszcze nie istnieje): checklista kroków
+tej procedury, którą będziesz odhaczać w trakcie pracy:
+
+```markdown
+# <nazwa> — postęp budowy
+- [ ] 1. Pin
+- [ ] 2. Overlay (zadania typu "napraw")
+- [ ] 3. prompt.md
+- [ ] 4. Asercje (+ diffy kalibracyjne)
+- [ ] 5. Wagi
+- [ ] 6. Samosprawdzenie
+- [ ] 7. Oddanie pracy
+```
+
+Aktualizuj go **bezpośrednio po każdym kroku** (zasada 9): odhaczenie
+plus jedno-dwa zdania konkretu — wybrany SHA, nazwy zbudowanych
+asercji, wynik `bench assert`. W krokach długich (asercje,
+samosprawdzenie) dopisuj także w trakcie, po każdej domkniętej
+bramce, a problemy i decyzje notuj w momencie ich podjęcia. Ten plik
+czyta na żywo orkiestrator i użytkownik — ma opisywać stan faktyczny,
+nie plan; wpis wsteczny uzupełniony tuż przed raportem mija się
+z celem.
+
+Przy oddaniu pracy (krok 7) todo.md **usuwasz** — także przy odmowie
+(wtedy usuń również katalog zadania, jeśli nic poza todo.md w nim nie
+powstało). Wszystko, co ma przetrwać, należy do raportu końcowego.
 
 ### 1. Pin
 
@@ -244,7 +281,10 @@ Zostaw komplet plików w drzewie roboczym: katalog zadania + ewentualne
 nowe asercje w puli + zbiór kalibracyjny. Nic w gicie (zasada 1) —
 o commicie/PR-rze decyduje użytkownik. Wzorcowego rozwiązania **nie**
 zostawiaj w `tasks/` (przeciekłoby do workspace'u agenta) — jego
-miejsce to `evaluation-pool/judge/<zadanie>-calibration/`.
+miejsce to `evaluation-pool/judge/<zadanie>-calibration/`. Na koniec
+usuń `tasks/<nazwa>/todo.md` (zasada 9) — plik postępu to kanał
+podglądu na czas budowy, nie część zadania; pozostawiony wszedłby
+w `task_hash`.
 
 ### 8. Raport końcowy
 


### PR DESCRIPTION
Każdy subagent budujący zadanie tworzy todo.md jako pierwszą czynność
(krok 0 TASK_AUTHORING.md) i odhacza kroki procedury na bieżąco, żeby
orkiestrator i użytkownik mogli podglądać pracę w toku. Przy oddaniu
pracy plik jest usuwany — task_hash liczy się ze wszystkich plików
katalogu zadania, więc plik roboczy nie może zostać w drzewie.
Orkiestrator przypomina o tym w prompcie fan-outu i używa todo.md do
diagnozy utkniętych subagentów.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WJ7R3e4JXriYQf4GxcJPfF